### PR TITLE
Add MDX talk to a new Talks section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,7 @@ MDX is a JSX in Markdown loader, parser, and renderer for ambitious projects. It
 - [Official](#official)
 - [Projects](#projects)
 - [Plugins](#plugins)
+- [Talks](#talks)
 - [Related Lists](#related-lists)
 
 
@@ -41,6 +42,9 @@ MDX is a JSX in Markdown loader, parser, and renderer for ambitious projects. It
 - [vscode-mdx-preview](https://github.com/xyc/vscode-mdx-preview) - MDX Preview for VSCode.
 - [gatsby-mdx](https://github.com/ChristopherBiscardi/gatsby-mdx) - MDX integration for Gatsby.
 
+## Talks
+
+- [MDX: content for kings and princesses](https://github.com/DeveloperMode/mdx-fairy-tale)
 
 ## Related Lists
 


### PR DESCRIPTION
I recently gave a [talk about MDX](https://github.com/DeveloperMode/mdx-fairy-tale) and thought I'd add it here. I wasn't sure if any of the existing sections were a good fit, so I created a new one simply called "Talks". Let me know if that sounds good or I can make a change.

Thanks for maintaining a great resource here.