### PR TITLE
Updated Next.js-related links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ MDX is a JSX in Markdown loader, parser, and renderer for ambitious projects. It
 ## Plugins
 
 - [inline-mdx](https://github.com/hamlim/inline-mdx.macro) - Babel [macro](https://github.com/kentcdodds/babel-plugin-macros) for transforming MDX inline.
-- [next-mdx](https://github.com/zeit/next-plugins/tree/master/packages/next-mdx) - MDX plugin for [Next.js](https://github.com/zeit/next.js).
+- [next-mdx](https://github.com/vercel/next.js/tree/canary/packages/next-mdx) - MDX plugin for [Next.js](https://github.com/vercel/next.js).
 - [razzle-plugin-mdx](https://github.com/jaredpalmer/razzle/tree/master/packages/razzle-plugin-mdx) - MDX plugin for [Razzle](https://github.com/jaredpalmer/razzle).
 - [eslint-plugin-mdx](https://github.com/azz/eslint-plugin-mdx) - ESLint Plugin for MDX.
 - [vscode-mdx-preview](https://github.com/xyc/vscode-mdx-preview) - MDX Preview for VSCode.


### PR DESCRIPTION
Since Vercel shuffled GitHub repos around

<!--
Read the [contributing guidelines](https://mdxjs.com/contributing).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://mdxjs.com/support
https://mdxjs.com/contributing
-->
